### PR TITLE
FIX: typo in regex for README.md example

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ class PagesController < ApplicationController
   def fetch_page_id(params)
     id = params.fetch(:id)
 
-    unless id =~ /d+/ # friendly_id gem compatability
+    unless id =~ /\d+/ # friendly_id gem compatability
       id = Seo.page_class.find(id).id
     end
 


### PR DESCRIPTION
This example code would mean the redirect would fail for slugs containing the letter 'd' :smiley: 
