### PR TITLE
add nav_item helper to mark active selected paths

### DIFF
--- a/app/helpers/seo/navigation_helper.rb
+++ b/app/helpers/seo/navigation_helper.rb
@@ -1,0 +1,32 @@
+module Seo
+  module NavigationHelper
+    # Usage:
+    #
+    # nav_item(:resource_path)
+    # nav_item(:resource_path, "Custom Title")
+    #
+    def nav_item(path, title=false)
+      path_name = path.to_s.gsub('_path', '')
+
+      content_tag :li, class: nav_css_class(path_name) do
+        content_tag :a, href: public_send(path) do
+          title || path_name.titleize
+        end
+      end
+    end
+
+    private
+
+    def nav_css_class(path)
+      'active' if resolves_to_current_controller?(path)
+    end
+
+    def resolves_to_current_controller?(path)
+      controller.url_options[:_path_segments][:controller] == named_route_controller(path.to_s.gsub('_path', ''))
+    end
+
+    def named_route_controller(named_route)
+      ::Seo::Engine.routes.named_routes.routes[named_route.to_sym].defaults[:controller]
+    end
+  end
+end

--- a/app/views/layouts/seo/application.html.erb
+++ b/app/views/layouts/seo/application.html.erb
@@ -24,7 +24,7 @@
       <div class="row">
         <div class="col-sm-3 col-md-2 sidebar">
           <ul class="nav nav-sidebar">
-            <li class="active"><a href="<%= permanent_redirects_path %>">Permanent Redirects</a></li>
+	    <%= nav_item(:permanent_redirects_path) %>
 	    <li class="disabled"><a href="#">Manage meta tags</a></li>
 	    <li class="disabled"><a href="#">Manage robots.txt</a></li>
             <li class="disabled"><a href="#">Add google tracking code</a></li>


### PR DESCRIPTION
If the current controller in use matches the controller which the `:resource_path` resolves to then mark the list item as `active`.
### Usage

``` erb
<ul>
  <%= nav_item(:permanent_redirects) %>
  <%= nav_item(:meta_contents_path, "Manage Meta Tags") %>
</ul>
```
