### PR TITLE
Meta tags

### DIFF
--- a/app/concerns/seo/meta_tags.rb
+++ b/app/concerns/seo/meta_tags.rb
@@ -1,0 +1,57 @@
+module Seo
+  module MetaTags
+    mattr_accessor :default_title
+    extend ActiveSupport::Concern
+
+    included do
+      before_filter :set_seo_tags
+
+      protected
+
+      def set_seo_tags
+        _set_title_tag
+        _set_meta_description_tag
+        _set_meta_keywords_tag
+      end
+
+      def meta_content
+        @meta_content ||=
+          MetaContent.where(resource_type: _resource_model_for_meta_tags,
+                            resource_id: _resource_id_for_meta_tags).first
+      end
+
+      private
+
+      def _set_title_tag
+        @title = _resource_meta_title || Seo::MetaTags.default_title
+      end
+
+      def _set_meta_description_tag
+        @meta_description = meta_content.meta_description
+      rescue
+        # NOOP
+      end
+
+      def _set_meta_keywords_tag
+        @meta_keywords = meta_content.meta_keywords
+      rescue
+        # NOOP
+      end
+
+      def _resource_meta_title
+        raise if meta_content.meta_title.strip.blank?
+        meta_content.meta_title
+      rescue
+        # NOOP
+      end
+
+      def _resource_model_for_meta_tags
+        controller_name.singularize.capitalize
+      end
+
+      def _resource_id_for_meta_tags
+        params[:id]
+      end
+    end
+  end
+end

--- a/app/views/seo/application/_meta_tags.html.erb
+++ b/app/views/seo/application/_meta_tags.html.erb
@@ -1,0 +1,3 @@
+<title><%= @title %></title>
+<meta name="description" content="<%= @meta_description %>" />
+<meta name="keywords" content="<%= @meta_keywords %>" />

--- a/spec/dummy/app/controllers/application_controller.rb
+++ b/spec/dummy/app/controllers/application_controller.rb
@@ -1,3 +1,6 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery
+
+  include Seo::MetaTags
+  Seo::MetaTags.default_title = "Dummy"
 end

--- a/spec/dummy/app/views/layouts/application.html.erb
+++ b/spec/dummy/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title>Dummy</title>
+  <%= render 'seo/application/meta_tags' %>
   <%= stylesheet_link_tag    "application", :media => "all" %>
   <%= javascript_include_tag "application" %>
   <%= csrf_meta_tags %>

--- a/spec/features/meta_tags_spec.rb
+++ b/spec/features/meta_tags_spec.rb
@@ -13,9 +13,7 @@ feature %[
 
   background do
     page_one # eager load to populate the database
-  end
 
-  scenario "adding meta content for a resource" do
     visit '/seo/meta_contents'
 
     click_link "New"
@@ -27,11 +25,10 @@ feature %[
     fill_in "meta_content_meta_description", with: meta_description
     fill_in "meta_content_meta_keywords", with: meta_keywords
 
-    expect{ click_on "Create Meta content" }.not_to raise_error
+    click_on "Create Meta content"
   end
 
   scenario "addind a meta title, description and keywords" do
-    pending
     visit page_path(page_one)
     expect(html).to include(meta_title)
     expect(html).to include(meta_description)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@ ENV['RAILS_ENV'] ||= 'test'
 
 require File.expand_path("../dummy/config/environment.rb", __FILE__)
 require 'rspec/rails'
+require 'coffee_script'
 require 'rspec/autorun'
 require 'database_cleaner'
 require 'pry-nav'


### PR DESCRIPTION
This finishes off the user story below, following on from #8, by adding a partial to use within an application to render the tags defined in the UI.

``` erb
<%= render 'seo/application/meta_tags' %>
```

This partial will output a title, meta description and meta keyword tags when it can.

Specifically this figures out what model to use based on the controller name, but there is a method (or two) to override within each controller when Rails conventions have not been followed.

The main method to override would be:

``` ruby
def meta_content
  @meta_content ||=
    MetaContent.where(resource_type: _resource_model_for_meta_tags, resource_id: _resource_id_for_meta_tags).first
end
```

User story:

```
As a SEO Administrator
I want to be able to manage all the meta tags in one place
So that I can make updates from my SEO audit without hunting down the right place in a disparate admin CMS
```
